### PR TITLE
Fix export define for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,11 +118,18 @@ install(FILES ${CMAKE_BINARY_DIR}/LibPlumConfigVersion.cmake
 
 if(NOT NO_EXPORT_HEADER AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
 	include(GenerateExportHeader)
-	generate_export_header(plum)
+	generate_export_header(plum
+		EXPORT_MACRO_NAME PLUM_EXPORT
+		NO_EXPORT_MACRO_NAME PLUM_NO_EXPORT
+		DEPRECATED_MACRO_NAME PLUM_DEPRECATED
+		STATIC_DEFINE PLUM_STATIC)
 	target_include_directories(plum PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 	target_compile_definitions(plum PUBLIC -DPLUM_HAS_EXPORT_HEADER)
 	set_target_properties(plum PROPERTIES C_VISIBILITY_PRESET hidden)
 	install(FILES ${PROJECT_BINARY_DIR}/plum_export.h DESTINATION include/plum)
+else()
+	target_compile_definitions(plum PRIVATE PLUM_EXPORTS)
+	target_compile_definitions(plum-static PRIVATE PLUM_EXPORTS)
 endif()
 
 if(NOT MSVC)

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ LIBS=
 INCLUDES=-Iinclude/plum
 LDLIBS=
 
+CFLAGS+=-DPLUM_EXPORTS
+
 ifneq ($(LIBS), "")
 INCLUDES+=$(if $(LIBS),$(shell pkg-config --cflags $(LIBS)),)
 LDLIBS+=$(if $(LIBS), $(shell pkg-config --libs $(LIBS)),)

--- a/include/plum/plum.h
+++ b/include/plum/plum.h
@@ -29,13 +29,19 @@ extern "C" {
 
 #ifdef PLUM_HAS_EXPORT_HEADER
 #include "plum_export.h"
-#endif
-
-#ifndef PLUM_EXPORT
-#ifdef _WIN32
-#define PLUM_EXPORT __declspec(dllexport)
-#else
+#else // no export header
+#ifdef PLUM_STATIC
 #define PLUM_EXPORT
+#else // dynamic library
+#ifdef _WIN32
+#if defined(PLUM_EXPORTS) || defined(plum_EXPORTS)
+#define PLUM_EXPORT __declspec(dllexport) // building the library
+#else
+#define PLUM_EXPORT __declspec(dllimport) // using the library
+#endif
+#else // not WIN32
+#define PLUM_EXPORT
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This PR fixes the export define for Windows when not using the export header, as previously it would lead to incorrect behavior, for instance re-exported symbols when used as a static library in a dynamic library.