### PR TITLE
Fix invalid mutex unlock when starting client

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -115,10 +115,8 @@ void client_destroy(client_t *client) {
 }
 
 int client_start(client_t *client) {
-	if (atomic_load(&client->is_started)) {
-		mutex_unlock(&client->protocol_mutex);
+	if (atomic_load(&client->is_started))
 		return 0;
-	}
 
 	int ret = thread_init(&client->thread, client_thread_entry, client);
 	if (ret) {

--- a/src/client.h
+++ b/src/client.h
@@ -38,7 +38,7 @@ typedef struct {
 	const protocol_t *protocol;
 	protocol_state_t protocol_state;
 	mutex_t protocol_mutex;
-	atomic(bool) is_started;
+	bool is_started;
 	atomic(bool) is_stopping;
 	thread_t thread;
 } client_t;


### PR DESCRIPTION
The PR fixes a leftover invalid `mutex_unlock()` call when starting client and refactors `is_started` flag to non-atomic.