### PR TITLE
Remove deprecated ATOMIC_VAR_INIT macro

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -31,7 +31,7 @@ static const char *log_level_colors[] = {
     "\x1B[97m\x1B[41m" // white on red
 };
 
-static atomic(plum_log_level_t) log_level = ATOMIC_VAR_INIT(PLUM_LOG_LEVEL_NONE);
+static atomic(plum_log_level_t) log_level = PLUM_LOG_LEVEL_NONE;
 static plum_log_callback_t log_callback = NULL;
 static mutex_t log_mutex;
 

--- a/src/pcp.c
+++ b/src/pcp.c
@@ -33,7 +33,7 @@ int pcp_init(protocol_state_t *state) {
 	impl->mcast_sock = INVALID_SOCKET;
 	impl->has_prev_server_time = false;
 	impl->use_natpmp = false;
-	impl->interrupt = ATOMIC_VAR_INIT(PCP_INTERRUPT_NONE);
+	impl->interrupt = PCP_INTERRUPT_NONE;
 
 	udp_socket_config_t udp_config;
 	memset(&udp_config, 0, sizeof(udp_config));

--- a/src/thread.h
+++ b/src/thread.h
@@ -139,7 +139,6 @@ static inline int cond_timedwait_impl(cond_t *c, mutex_t *m, unsigned int msecs)
 #define atomic_ptr(T) T *volatile
 #define atomic_store(a, v) (void)(*(a) = (v))
 #define atomic_load(a) (*(a))
-#define ATOMIC_VAR_INIT(v) (v)
 
 #endif // if atomics
 

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -39,7 +39,7 @@ int upnp_init(protocol_state_t *state) {
 	*impl->external_addr_str = '\0';
 	impl->location_url = NULL;
 	impl->control_url = NULL;
-	impl->interrupt = ATOMIC_VAR_INIT(UPNP_INTERRUPT_NONE);
+	impl->interrupt = UPNP_INTERRUPT_NONE;
 
 	udp_socket_config_t udp_config;
 	memset(&udp_config, 0, sizeof(udp_config));


### PR DESCRIPTION
This PR removes the `ATOMIC_VAR_INIT` macro. It is useless in C11, deprecated in C17, and removed in C23.