### PR TITLE
cmake: Various fixes for static library builds and packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,13 @@ install(TARGETS plum EXPORT LibPlumTargets
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
+install(TARGETS plum-static EXPORT LibPlumTargets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	OPTIONAL
+)
+
 install(FILES ${LIBPLUM_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plum)
 
 # Export Targets
@@ -103,19 +110,25 @@ install(
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibPlum
 )
 
-# Export config
-install(
-    FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibPlumConfig.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibPlum
-)
-
 include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibPlumConfig.cmake.in
+    ${CMAKE_BINARY_DIR}/LibPlumConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibPlum
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
 write_basic_package_version_file(
     ${CMAKE_BINARY_DIR}/LibPlumConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion)
-install(FILES ${CMAKE_BINARY_DIR}/LibPlumConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibPlum)
+    COMPATIBILITY SameMajorVersion
+)
+# Export config and version files
+install(FILES
+    ${CMAKE_BINARY_DIR}/LibPlumConfig.cmake
+    ${CMAKE_BINARY_DIR}/LibPlumConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibPlum
+)
 
 set_target_properties(plum PROPERTIES C_VISIBILITY_PRESET hidden)
 target_compile_definitions(plum PRIVATE PLUM_EXPORTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(PROJECT_DESCRIPTION "Multi-protocol Port Mapping client library")
 option(NO_EXAMPLE "Disable example build" OFF)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 
-set(C_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ install(FILES
 
 set_target_properties(plum PROPERTIES C_VISIBILITY_PRESET hidden)
 target_compile_definitions(plum PRIVATE PLUM_EXPORTS)
-target_compile_definitions(plum-static PRIVATE PLUM_EXPORTS)
+target_compile_definitions(plum-static PRIVATE PLUM_EXPORTS PUBLIC PLUM_STATIC)
 
 if(NOT MSVC)
 	target_compile_options(plum PRIVATE -Wall -Wextra)

--- a/cmake/LibPlumConfig.cmake.in
+++ b/cmake/LibPlumConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/LibPlumTargets.cmake")


### PR DESCRIPTION
This patchset addresses four issues:

1. Consumers of the library, which want to use `plum-static`, need to set `PLUM_STATIC` macro automatically, so they don't try to enforce visibility attributes for LibPlum's symbols.
2. There was an incorrect setting for project-wide C standard used, which should be `CMAKE_C_STANDARD` instead of `C_STANDARD`.
3. `cmake --install` didn't work because of nonexistent `cmake/LibPlumConfig.cmake` referenced in the main `CMakeLists.txt`. Now it's correctly auto-generated via `cmake/LibPlumConfig.cmake.in` + `configure_package_config_file()` combination.
4. `plum-static` should also be installed on `cmake --install`, so it's added to the targets export set for CMake.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>