### PR TITLE
http.c: Fix -Wincompatible-pointer-types-discards-qualifiers

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -43,7 +43,7 @@ static int http_perform_rec(const http_request_t *request, http_response_t *resp
 		return -1;
 	}
 
-	char *service;
+	const char *service;
 	char *separator = strchr(host, ':');
 	if (separator) {
 		*separator = '\0';


### PR DESCRIPTION
The line:
```c
service = "80";
```
may trigger `Wincompatible-pointer-types-discards-qualifiers`:
```
http.c:52:11: assigning to 'char *' from 'const char[3]' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
```