### PR TITLE
log: place `__exit` goto label under #ifdef to avoid `-Wunused-label` warnings

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -136,6 +136,10 @@ void plum_log_write(plum_log_level_t level, const char *file, int line, const ch
 		fflush(stdout);
 	}
 
+#if !RELEASE
+	// Place the goto label under #ifdef so that this code doesn't
+	// trigger `-Wunused-label` warning in release builds.
 __exit:
+#endif
 	mutex_unlock(&log_mutex);
 }


### PR DESCRIPTION
`plum_log_write()` triggers `-Wunused-label` warning in Release builds, because `__exit` label isn't used.

Fix that by #ifdef-ing the label so that it's not there if building in Release mode.