### PR TITLE
Fix UPnP with many routers by supporting WANIPConnection:2

### DIFF
--- a/src/upnp.h
+++ b/src/upnp.h
@@ -31,6 +31,7 @@ typedef struct {
 	socket_t sock;
 	char external_addr_str[ADDR_MAX_STRING_LEN];
 	char *location_url;
+	int wanipconnection_ver;
 	char *control_url;
 	atomic(upnp_interrupt_t) interrupt;
 } upnp_impl_t;


### PR DESCRIPTION
Some routers only advertise UPnP's `WANIPConnection:2` service. Apparently there are quite a lot of these routers (and many don't seem to support newer standards like NAT-PMP or PCP either).

libplum previously only checked for and handled `WANIPConnection:1`, causing port mapping to fail on these routers.

Fortunately `WANIPConnection:2` is "fully compliant with WANIPConnection:1 service, except in cases where access control has been added". (PDF spec link: https://upnp.org/specs/gw/UPnP-gw-WANIPConnection-v2-Service.pdf)

This PR implements basic support for `WANIPConnection:2`, which requires very few changes (mostly just handling the different version number, plus the new `729 - ConflictWithOtherMechanisms` error code).

Tested on several routers that were previously problematic - UPnP now succeeds with this patch.