### PR TITLE
tcp: treat POLLHUP as a zero-byte read to avoid endless loop

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -141,6 +141,10 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 
 			return len;
 		}
+
+		if (pfd.revents & POLLHUP) {
+			return 0;
+		}
 	}
 
 	// Timeout

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -124,7 +124,7 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 			return -1;
 		}
 
-		if (pfd.revents & POLLIN) {
+		if (pfd.revents & POLLIN || pfd.revents & POLLHUP) {
 #if defined(__APPLE__) || defined(_WIN32)
 			int flags = 0;
 #else
@@ -140,10 +140,6 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 			}
 
 			return len;
-		}
-
-		if (pfd.revents & POLLHUP) {
-			return 0;
 		}
 	}
 


### PR DESCRIPTION
On Windows, the library was getting stuck in an endless loop when doing an HTTP look-up.

It turned out that the peer was sending all the data and then hanging up, and on Windows this needs to be detected via POLLHUP. If we treat POLLHUP as a zero-byte read, we escape from the endless loop.

I didn't see the same issue on the other platforms I tried (Ubuntu x64, Jetson arm64), even when communicating with the same router.