### PR TITLE
upnp: create a dedicated socket to interrupt the client

### DIFF
--- a/src/upnp.h
+++ b/src/upnp.h
@@ -29,6 +29,7 @@ typedef enum { UPNP_INTERRUPT_NONE, UPNP_INTERRUPT_SOFT, UPNP_INTERRUPT_HARD } u
 
 typedef struct {
 	socket_t sock;
+	socket_t interrupt_sock;
 	char external_addr_str[ADDR_MAX_STRING_LEN];
 	char *location_url;
 	int wanipconnection_ver;


### PR DESCRIPTION
On Windows, I found the client interruption mechanism wasn't working for UPnP. I traced this to the poll not being triggered when the interruption UDP message was sent.

I tried various other solutions, including adding some bytes to the message (rather than send a zero-byte) message but the only way I can get the poll to trigger, on Windows, is with a second dedicated UDP socket created for this purpose.

I reproduced this on the two Windows 11 platforms I tested it on. It would be interesting to hear if others experience the same issue?

Ideally there would be a way of getting the impl->sock to work, but I couldn't find it! I speculate that this is caused by the use of the impl->sock for broadcasts and something becoming screwed on the Windows platform due to this. I even created an identical socket to impl->sock (same config flags, setup for broadcast etc) and found this *did* trigger the interrupt. The only difference with this socket was that I didn't call any send or recv on it prior to using it for the interruption.

Note that PCP does not have this issue, the impl->sock on that protocol interrupts on Windows ok. The difference is the impl->sock on PCP never operates in broadcast mode...?

I have implemented this PR on all platforms for the sake of simplicity (i.e. I've not wrapped this in a Windows definition).