### PR TITLE
http: propagate tcp timeout errors

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -15,6 +15,9 @@
 #define HTTP_MAX_HOST_LEN 256
 #define HTTP_MAX_URL_LEN 1024
 
+#define HTTP_ERR_UNKNOWN -1
+#define HTTP_ERR_TIMEOUT -2
+
 typedef enum http_method {
 	HTTP_METHOD_GET,
 	HTTP_METHOD_POST,

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -112,7 +112,7 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 				continue;
 			} else {
 				PLUM_LOG_ERROR("poll failed, errno=%d", sockerrno);
-				return -1;
+				return TCP_ERR_UNKNOWN;
 			}
 		}
 
@@ -121,7 +121,7 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 
 		if (pfd.revents & POLLNVAL || pfd.revents & POLLERR) {
 			PLUM_LOG_ERROR("Error when polling socket");
-			return -1;
+			return TCP_ERR_UNKNOWN;
 		}
 
 		if (pfd.revents & POLLIN || pfd.revents & POLLHUP) {
@@ -136,7 +136,7 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 					continue;
 
 				PLUM_LOG_WARN("TCP recv failed, errno=%d", sockerrno);
-				return -1;
+				return TCP_ERR_UNKNOWN;
 			}
 
 			return len;
@@ -145,7 +145,7 @@ int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp
 
 	// Timeout
 	PLUM_LOG_WARN("TCP recv timeout");
-	return -1;
+	return TCP_ERR_TIMEOUT;
 }
 
 int tcp_send(socket_t sock, const char *data, size_t size, timestamp_t end_timestamp) {
@@ -166,7 +166,7 @@ int tcp_send(socket_t sock, const char *data, size_t size, timestamp_t end_times
 				continue;
 			} else {
 				PLUM_LOG_ERROR("poll failed, errno=%d", sockerrno);
-				return -1;
+				return TCP_ERR_UNKNOWN;
 			}
 		}
 
@@ -175,7 +175,7 @@ int tcp_send(socket_t sock, const char *data, size_t size, timestamp_t end_times
 
 		if (pfd.revents & POLLNVAL || pfd.revents & POLLERR) {
 			PLUM_LOG_ERROR("Error when polling socket");
-			return -1;
+			return TCP_ERR_UNKNOWN;
 		}
 
 		if (pfd.revents & POLLOUT) {
@@ -190,7 +190,7 @@ int tcp_send(socket_t sock, const char *data, size_t size, timestamp_t end_times
 					continue;
 
 				PLUM_LOG_WARN("TCP send failed, errno=%d", sockerrno);
-				return -1;
+				return TCP_ERR_UNKNOWN;
 			}
 
 			data += len;
@@ -204,5 +204,5 @@ int tcp_send(socket_t sock, const char *data, size_t size, timestamp_t end_times
 	// Timeout
 	PLUM_LOG_WARN("TCP send timeout");
 	size_t sent = size - left;
-	return sent == 0 ? -1 : (int)sent;
+	return sent == 0 ? TCP_ERR_TIMEOUT : (int)sent;
 }

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -15,6 +15,9 @@
 
 #include <stdint.h>
 
+#define TCP_ERR_UNKNOWN -1
+#define TCP_ERR_TIMEOUT -2
+
 socket_t tcp_connect_socket(const addr_record_t *remote_addr, timestamp_t end_timestamp);
 int tcp_recv(socket_t sock, char *buffer, size_t size, timestamp_t end_timestamp);
 int tcp_send(socket_t sock, const char *data, size_t size, timestamp_t end_timestamp);

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -321,10 +321,16 @@ int upnp_impl_query_control_url(upnp_impl_t *impl, timestamp_t end_timestamp) {
 	request.headers = "";
 
 	http_response_t response;
+	memset(&response, 0, sizeof(response));
 	int ret = http_perform(&request, &response, end_timestamp);
 	if (ret < 0) {
-		PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
-		return PROTOCOL_ERR_UNKNOWN;
+        if (ret == HTTP_ERR_TIMEOUT) {
+            PLUM_LOG_WARN("Timed-out sending HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_TIMEOUT;
+        } else {
+            PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_NETWORK_FAILED;
+        }
 	}
 
 	if (ret != 200) {
@@ -455,10 +461,16 @@ int upnp_impl_query_external_addr(upnp_impl_t *impl, timestamp_t end_timestamp) 
 	request.body_type = "text/xml; charset=\"utf-8\"";
 
 	http_response_t response;
+	memset(&response, 0, sizeof(response));
 	int ret = http_perform(&request, &response, end_timestamp);
 	if (ret < 0) {
-		PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
-		return PROTOCOL_ERR_NETWORK_FAILED;
+        if (ret == HTTP_ERR_TIMEOUT) {
+            PLUM_LOG_WARN("Timed-out sending HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_TIMEOUT;
+        } else {
+            PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_NETWORK_FAILED;
+        }
 	}
 
 	if (ret != 200) {
@@ -544,10 +556,16 @@ int upnp_impl_map(upnp_impl_t *impl, plum_ip_protocol_t protocol, uint16_t exter
 	request.body_type = "text/xml; charset=\"utf-8\"";
 
 	http_response_t response;
+	memset(&response, 0, sizeof(response));
 	int ret = http_perform(&request, &response, end_timestamp);
 	if (ret < 0) {
-		PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
-		return PROTOCOL_ERR_NETWORK_FAILED;
+        if (ret == HTTP_ERR_TIMEOUT) {
+            PLUM_LOG_WARN("Timed-out sending HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_TIMEOUT;
+        } else {
+            PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_NETWORK_FAILED;
+        }
 	}
 
 	if (ret != 200) {
@@ -614,10 +632,16 @@ int upnp_impl_unmap(upnp_impl_t *impl, plum_ip_protocol_t protocol, uint16_t ext
 	request.body_type = "text/xml; charset=\"utf-8\"";
 
 	http_response_t response;
+	memset(&response, 0, sizeof(response));
 	int ret = http_perform(&request, &response, end_timestamp);
 	if (ret < 0) {
-		PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
-		return PROTOCOL_ERR_NETWORK_FAILED;
+        if (ret == HTTP_ERR_TIMEOUT) {
+            PLUM_LOG_WARN("Timed-out sending HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_TIMEOUT;
+        } else {
+            PLUM_LOG_WARN("Failed to send HTTP request to UPnP-IGD device");
+            return PROTOCOL_ERR_NETWORK_FAILED;
+        }
 	}
 
 	if (ret != 200) {


### PR DESCRIPTION
This PR defines two error codes for tcp_send/recv according to whether the error was a timeout or another error. This is used to fill in a new timed_out flag in the http response structure. Finally this is checked by the upnp protocol code to return PROTOCOL_ERR_TIMEOUT if necessary.

This means that if a protocol fails to complete successfully due to a TCP timeout it will be retried under the same system that is used for timing out waiting for broadcast responses.