### PR TITLE
This fixes a warning seen on certain platforms/compiler versions

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -166,7 +166,7 @@ int net_get_default_gateway(int family, addr_record_t *record) {
 			goto error;
 		}
 
-		if (snl_len < sizeof(snl) || snl.nl_pid != 0) {
+		if (snl_len < (socklen_t)sizeof(snl) || snl.nl_pid != 0) {
 			PLUM_LOG_WARN("Netlink received datagram not from kernel");
 			continue;
 		}


### PR DESCRIPTION
In my case it was compiling for Android using using NDK 27.

```
XXXXX/net.c:169:15: error: comparison of integers of different signs: 'socklen_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
  169 |                 if (snl_len < sizeof(snl) || snl.nl_pid != 0) {
      |                     ~~~~~~~ ^ ~~~~~~~~~~~
1 error generated.
```