### PR TITLE
net: fixed missing closesocket on linux when getting default gateway

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -194,6 +194,7 @@ int net_get_default_gateway(int family, addr_record_t *record) {
 
 					if (rta->rta_type == RTA_GATEWAY) {
 						addr_set_binary(family, RTA_DATA(rta), 0, record);
+						closesocket(sock);
 						return 0;
 					}
 				}


### PR DESCRIPTION
I had adapted the code to run updates/refreshes more frequently and found that after a day or so the system ran out to file descriptors.

I trace it back to a missing closesocket() call after successfully retrieving the default gateway on Linux.