### PR TITLE
Fix for udp_sendto_self not working on Windows

### DIFF
--- a/src/upnp.c
+++ b/src/upnp.c
@@ -48,7 +48,7 @@ int upnp_init(protocol_state_t *state) {
 	udp_config.enable_broadcast = true;
 	impl->sock = udp_create_socket(&udp_config);
 	if (impl->sock == INVALID_SOCKET) {
-		PLUM_LOG_ERROR("UDP socket creation on port 1900 failed");
+		PLUM_LOG_ERROR("UDP socket creation failed");
 		goto error;
 	}
 

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -44,9 +44,8 @@ int upnp_init(protocol_state_t *state) {
 	udp_socket_config_t udp_config;
 	memset(&udp_config, 0, sizeof(udp_config));
 	udp_config.family = AF_INET;
-	udp_config.port = 1900;
+	udp_config.port = 0; // Binding explicitly to the SSDP port prevents udp_sendto_self from working on Windows
 	udp_config.enable_broadcast = true;
-	udp_config.enable_reuseaddr = true;
 	impl->sock = udp_create_socket(&udp_config);
 	if (impl->sock == INVALID_SOCKET) {
 		PLUM_LOG_ERROR("UDP socket creation on port 1900 failed");


### PR DESCRIPTION
On Windows udp_sendto_self does not work when we bind to the same port (1900) that is used for the multicast broadcast and receive.

It appears to silently drop/ignore the packet, sendto does not report an error and the local address is valid (127.0.0.1:1900).

Any other port, or zero, does not exhibit this problem.