### PR TITLE
Fix downgrading to nat-pmp

### DIFF
--- a/src/pcp.c
+++ b/src/pcp.c
@@ -330,11 +330,6 @@ int pcp_impl_probe(pcp_impl_t *impl, addr_record_t *found_gateway, timestamp_t e
 			continue;
 		}
 
-		if (len < (int)sizeof(struct pcp_response_header)) {
-			PLUM_LOG_WARN("Announce response of length %d is too short", len);
-			continue;
-		}
-
 		uint8_t result = common_header->result;
 		uint8_t version = common_header->version;
 		if (result != PCP_RESULT_SUCCESS) {
@@ -355,6 +350,11 @@ int pcp_impl_probe(pcp_impl_t *impl, addr_record_t *found_gateway, timestamp_t e
 				PLUM_LOG_WARN("Got PCP error response, result=%u", (unsigned int)result);
 				return PROTOCOL_ERR_PROTOCOL_FAILED;
 			}
+		}
+
+		if (len < (int)sizeof(struct pcp_response_header)) {
+			PLUM_LOG_WARN("Announce response of length %d is too short", len);
+			continue;
 		}
 
 		const struct pcp_response_header *header = (const struct pcp_response_header *)buffer;


### PR DESCRIPTION
Previously, response packets with less than 24 bytes were dropped without checking for downgrade requests, however nat-pmp specifies that downgrade requests must follow a format with 12 bytes in a packet (RFC 6886, section 3.2).

Additionally, it appears TP-Link's Archer A7 does not send the "undefined" IPv4 address at all, when it should send zeroed bytes in accordance to RFC6886 section 3.2. This results in 8-byte packets instead of 12-byte packets. Either way, the 4-byte common header is still sent, and only that is needed to downgrade.
