### PR TITLE
cmake: Set cmake_minimum_required policy_max

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required(VERSION 3.7...4.0)
 project (libplum
 	VERSION 0.5.1
 	LANGUAGES C)


### PR DESCRIPTION
To avoid a deprecation warning in CMake 3.31 and above

See: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version