### PR TITLE
feat: configurable timeouts and mapping lifecycle fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ build/
 *.so
 compile_commands.json
 tests
+example.out
 

--- a/include/plum/plum.h
+++ b/include/plum/plum.h
@@ -57,6 +57,9 @@ typedef struct {
 	plum_log_level_t log_level;
 	plum_log_callback_t log_callback; // NULL means stdout
 	const char *dummytls_domain;      // NULL means disabled
+	int discover_timeout; // msecs, 0 means use default (10000)
+	int mapping_timeout;  // msecs, 0 means use default (10000)
+	int recheck_period;   // msecs, 0 means use default (300000)
 } plum_config_t;
 
 PLUM_EXPORT int plum_init(const plum_config_t *config);

--- a/include/plum/plum.h
+++ b/include/plum/plum.h
@@ -99,7 +99,7 @@ typedef struct {
 	void *user_ptr;
 } plum_mapping_t;
 
-// Callback will be called on SUCCESS and FAILURE
+// Callback will be called on SUCCESS, FAILURE, and DESTROYED
 typedef void (*plum_mapping_callback_t)(int id, plum_state_t state, const plum_mapping_t *mapping);
 
 PLUM_EXPORT int plum_create_mapping(const plum_mapping_t *mapping,

--- a/include/plum/plum.h
+++ b/include/plum/plum.h
@@ -78,11 +78,20 @@ typedef enum {
 	PLUM_STATE_DESTROYING = 4
 } plum_state_t;
 
+typedef enum {
+	PLUM_MAPPING_PROTOCOL_UNKNOWN = 0,
+	PLUM_MAPPING_PROTOCOL_PCP = 1,
+	PLUM_MAPPING_PROTOCOL_NATPMP = 2,
+	PLUM_MAPPING_PROTOCOL_UPNP = 3,
+	PLUM_MAPPING_PROTOCOL_DIRECT = 4
+} plum_mapping_protocol_t;
+
 #define PLUM_MAX_HOST_LEN 256
 #define PLUM_MAX_ADDRESS_LEN 64
 
 typedef struct {
 	plum_ip_protocol_t protocol;
+	plum_mapping_protocol_t mapping_protocol;
 	uint16_t internal_port;
 	uint16_t external_port;
 	char external_host[PLUM_MAX_HOST_LEN];

--- a/include/plum/plum.h
+++ b/include/plum/plum.h
@@ -53,6 +53,7 @@ typedef enum {
 
 typedef void (*plum_log_callback_t)(plum_log_level_t level, const char *message);
 
+// Must be zero-initialized (e.g. plum_config_t config = {0}); unset fields fall back to defaults.
 typedef struct {
 	plum_log_level_t log_level;
 	plum_log_callback_t log_callback; // NULL means stdout

--- a/src/client.c
+++ b/src/client.c
@@ -307,6 +307,17 @@ static void reset_protocol(client_t *client) {
 	mutex_unlock(&client->mappings_mutex);
 }
 
+static void destroy_all_mappings(client_t *client) {
+	mutex_lock(&client->mappings_mutex);
+	for (int i = 0; i < client->mappings_size; ++i) {
+		client_mapping_t *cm = client->mappings + i;
+		// An empty slot has state PLUM_STATE_DESTROYED (== 0), so this skips it too
+		if (cm->state != PLUM_STATE_DESTROYED)
+			destroy_mapping(cm, i);
+	}
+	mutex_unlock(&client->mappings_mutex);
+}
+
 void client_run(client_t *client) {
 	PLUM_LOG_DEBUG("Starting client thread");
 	mutex_lock(&client->protocol_mutex);
@@ -397,6 +408,7 @@ void client_run(client_t *client) {
 	}
 
 	reset_protocol(client);
+	destroy_all_mappings(client);
 
 	PLUM_LOG_DEBUG("Exiting client thread");
 	mutex_unlock(&client->protocol_mutex);

--- a/src/client.c
+++ b/src/client.c
@@ -264,8 +264,11 @@ static bool has_destroying_mappings(client_t *client) {
 	mutex_lock(&client->mappings_mutex);
 	for (int i = 0; i < client->mappings_size; ++i) {
 		client_mapping_t *cm = client->mappings + i;
-		if (cm->state == PLUM_STATE_DESTROYING)
+		if (cm->state == PLUM_STATE_DESTROYING) {
+			// Must unlock before the early return, otherwise the mutex stays held
+			mutex_unlock(&client->mappings_mutex);
 			return true;
+		}
 	}
 	mutex_unlock(&client->mappings_mutex);
 	return false;
@@ -335,6 +338,8 @@ void client_run(client_t *client) {
 			err = client->protocol->init(&client->protocol_state);
 			if (err != PROTOCOL_ERR_SUCCESS) {
 				client->protocol = NULL;
+			} else {
+				client->protocol_state.recheck_period = client->recheck_period;
 			}
 		}
 
@@ -357,7 +362,10 @@ void client_run(client_t *client) {
 				PLUM_LOG_DEBUG("Mappings are marked for destruction, continuing");
 			}
 
-			if (protocol_num == PROTOCOL_NOPROTOCOL && !atomic_load(&client->is_stopping)) {
+			// Only retry discovery for a real NAT fallback, not for a stable public address
+			// (otherwise reset_protocol churns the mappings every cycle)
+			if (protocol_num == PROTOCOL_NOPROTOCOL && !atomic_load(&client->is_stopping) &&
+			    !addr_is_public((const struct sockaddr *)&local)) {
 				PLUM_LOG_DEBUG("NOPROTOCOL cycle done, retrying discovery");
 				reset_protocol(client);
 				protocol_num = 0;

--- a/src/client.c
+++ b/src/client.c
@@ -101,7 +101,6 @@ client_t *client_create(void) {
 
 	memset(client->mappings, 0, DEFAULT_MAPPINGS_SIZE * sizeof(client_mapping_t));
 	client->mappings_size = DEFAULT_MAPPINGS_SIZE;
-
 	mutex_init(&client->mappings_mutex, MUTEX_RECURSIVE); // so the user call the API from callbacks
 	mutex_init(&client->protocol_mutex, 0);
 
@@ -356,6 +355,12 @@ void client_run(client_t *client) {
 					break;
 				}
 				PLUM_LOG_DEBUG("Mappings are marked for destruction, continuing");
+			}
+
+			if (protocol_num == PROTOCOL_NOPROTOCOL && !atomic_load(&client->is_stopping)) {
+				PLUM_LOG_DEBUG("NOPROTOCOL cycle done, retrying discovery");
+				reset_protocol(client);
+				protocol_num = 0;
 			}
 			continue;
 		}

--- a/src/client.c
+++ b/src/client.c
@@ -341,7 +341,7 @@ void client_run(client_t *client) {
 		if (err == PROTOCOL_ERR_SUCCESS) {
 			mutex_unlock(&client->protocol_mutex);
 			err = client_run_protocol(client, client->protocol, &client->protocol_state,
-			                          CLIENT_RECHECK_PERIOD);
+			                          client->recheck_period);
 			mutex_lock(&client->protocol_mutex);
 		}
 
@@ -388,7 +388,7 @@ int client_run_protocol(client_t *client, const protocol_t *protocol,
                         protocol_state_t *protocol_state, timediff_t duration) {
 	timestamp_t end_timestamp = current_timestamp() + duration;
 
-	int err = protocol->discover(protocol_state, CLIENT_MAX_DISCOVER_TIMEOUT);
+	int err = protocol->discover(protocol_state, client->discover_timeout);
 	if (err != PROTOCOL_ERR_SUCCESS)
 		return err;
 
@@ -415,7 +415,7 @@ int client_run_protocol(client_t *client, const protocol_t *protocol,
 			if (mapping.state == PLUM_STATE_DESTROYING) {
 				PLUM_LOG_INFO("Performing unmapping for internal port %hu", mapping.internal_port);
 
-				err = protocol->unmap(protocol_state, &mapping, CLIENT_MAX_MAPPING_TIMEOUT);
+				err = protocol->unmap(protocol_state, &mapping, client->mapping_timeout);
 				if (err != PROTOCOL_ERR_SUCCESS)
 					return err;
 
@@ -430,7 +430,7 @@ int client_run_protocol(client_t *client, const protocol_t *protocol,
 				PLUM_LOG_INFO("Performing mapping for internal port %hu", mapping.internal_port);
 
 				protocol_map_output_t output;
-				err = protocol->map(protocol_state, &mapping, &output, CLIENT_MAX_MAPPING_TIMEOUT);
+				err = protocol->map(protocol_state, &mapping, &output, client->mapping_timeout);
 				if (err != PROTOCOL_ERR_SUCCESS)
 					return err;
 
@@ -479,8 +479,8 @@ int client_run_protocol(client_t *client, const protocol_t *protocol,
 		timestamp_t now = current_timestamp();
 		if (now < next_timestamp) {
 			timediff_t diff = next_timestamp - now;
-			if (diff > CLIENT_RECHECK_PERIOD)
-				diff = CLIENT_RECHECK_PERIOD;
+			if (diff > client->recheck_period)
+				diff = client->recheck_period;
 
 			err = protocol->idle(protocol_state, diff);
 			if (err != PROTOCOL_ERR_SUCCESS && err != PROTOCOL_ERR_TIMEOUT)

--- a/src/client.c
+++ b/src/client.c
@@ -58,6 +58,7 @@ static void import_mapping(const plum_mapping_t *mapping, plum_mapping_callback_
 static void export_mapping(const client_mapping_t *cm, plum_mapping_t *mapping) {
 	memset(mapping, 0, sizeof(*mapping));
 	mapping->protocol = cm->protocol;
+	mapping->mapping_protocol = cm->mapping_protocol;
 	mapping->internal_port = cm->internal_port;
 	mapping->user_ptr = cm->user_ptr;
 	if (cm->external_addr.len > 0) {
@@ -456,6 +457,7 @@ int client_run_protocol(client_t *client, const protocol_t *protocol,
 				free(cm->impl_record);
 				cm->impl_record = output.impl_record;
 				cm->refresh_timestamp = output.refresh_timestamp;
+				cm->mapping_protocol = output.mapping_protocol;
 
 				if (cm->state != PLUM_STATE_DESTROYING) { // mapping might have been destroyed
 					if (output.state == PROTOCOL_MAP_STATE_SUCCESS) {

--- a/src/client.c
+++ b/src/client.c
@@ -255,7 +255,11 @@ static void update_mapping(client_mapping_t *cm, int i, plum_state_t state,
 
 static void destroy_mapping(client_mapping_t *cm, int i) {
 	memset(&cm->external_addr, 0, sizeof(cm->external_addr));
-	update_mapping(cm, i, PLUM_STATE_DESTROYED, NULL);
+	// Do not call update_mapping here: it skips mappings already in DESTROYING.
+	// We need to notify the caller of destroyed state in order
+	// to provide a way to cleanup.
+	cm->state = PLUM_STATE_DESTROYED;
+	trigger_mapping_callback(cm, i);
 	free(cm->impl_record);
 	memset(cm, 0, sizeof(*cm));
 }

--- a/src/client.c
+++ b/src/client.c
@@ -234,7 +234,7 @@ static void trigger_mapping_callback(const client_mapping_t *cm, int i) {
 
 static void update_mapping(client_mapping_t *cm, int i, plum_state_t state,
                            const addr_record_t *external) {
-	if (cm->state == PLUM_STATE_DESTROYED || cm->state == PLUM_STATE_DESTROYING)
+	if (cm->state == PLUM_STATE_DESTROYED)
 		return;
 
 	bool changed = false;
@@ -255,11 +255,7 @@ static void update_mapping(client_mapping_t *cm, int i, plum_state_t state,
 
 static void destroy_mapping(client_mapping_t *cm, int i) {
 	memset(&cm->external_addr, 0, sizeof(cm->external_addr));
-	// Do not call update_mapping here: it skips mappings already in DESTROYING.
-	// We need to notify the caller of destroyed state in order
-	// to provide a way to cleanup.
-	cm->state = PLUM_STATE_DESTROYED;
-	trigger_mapping_callback(cm, i);
+	update_mapping(cm, i, PLUM_STATE_DESTROYED, NULL);
 	free(cm->impl_record);
 	memset(cm, 0, sizeof(*cm));
 }
@@ -381,7 +377,7 @@ void client_run(client_t *client) {
 			// (otherwise reset_protocol churns the mappings every cycle)
 			if (protocol_num == PROTOCOL_NOPROTOCOL && !atomic_load(&client->is_stopping) &&
 			    !addr_is_public((const struct sockaddr *)&local)) {
-				PLUM_LOG_DEBUG("NOPROTOCOL cycle done, retrying discovery");
+				PLUM_LOG_DEBUG("Retrying discovery");
 				reset_protocol(client);
 				protocol_num = 0;
 			}

--- a/src/client.h
+++ b/src/client.h
@@ -41,6 +41,9 @@ typedef struct {
 	bool is_started;
 	atomic(bool) is_stopping;
 	thread_t thread;
+	timediff_t discover_timeout;
+	timediff_t mapping_timeout;
+	timediff_t recheck_period;
 } client_t;
 
 client_t *client_create(void);

--- a/src/client.h
+++ b/src/client.h
@@ -21,6 +21,7 @@
 
 typedef struct client_mapping {
 	plum_ip_protocol_t protocol;
+	plum_mapping_protocol_t mapping_protocol;
 	uint16_t internal_port;
 	addr_record_t suggested_addr;
 	addr_record_t external_addr;

--- a/src/http.c
+++ b/src/http.c
@@ -170,27 +170,21 @@ static int http_perform_rec(const http_request_t *request, http_response_t *resp
 	PLUM_LOG_VERBOSE("Received HTTP response: %s", buffer);
 
 	int code = 0;
-	int header_len = 0;
-	// Parse status line: "HTTP/<version> <code> [reason]\r\n"
-	// %*s matches the version, then optionally skip the reason phrase.
-	// We use two patterns to handle responses with and without a reason phrase.
-	if (sscanf(buffer, "HTTP/%*s %d %*[^\r\n]%n", &code, &header_len) < 1 &&
-	    sscanf(buffer, "HTTP/%*s %d%n", &code, &header_len) < 1) {
+	// Status line: "HTTP/<version> <code> [reason]". Only the code is needed;
+	// the reason phrase may contain spaces and is ignored.
+	if (sscanf(buffer, "HTTP/%*s %d", &code) != 1 || code <= 0) {
 		PLUM_LOG_WARN("Failed to parse HTTP response status");
 		goto error;
 	}
-	if (code <= 0) {
-		PLUM_LOG_WARN("Failed to parse HTTP response status");
-		goto error;
-	}
-	// Find the end of the status line to advance past \r\n
-	const char *eol = strstr(buffer + header_len, "\r\n");
-	if (!eol) eol = strstr(buffer + header_len, "\n");
-	len = eol ? (int)(eol - buffer) + (eol[0] == '\r' ? 2 : 1) : header_len;
 
 	PLUM_LOG_DEBUG("Got HTTP response code %d", code);
 
-	char *headers_begin = buffer + len;
+	char *headers_begin = strstr(buffer, "\r\n");
+	if (!headers_begin) {
+		PLUM_LOG_WARN("Failed to parse HTTP response status");
+		goto error;
+	}
+	headers_begin += 2;
 	char *headers_end = strstr(headers_begin, "\r\n\r\n");
 	if (!headers_end) {
 		PLUM_LOG_WARN("Failed to parse HTTP response headers");

--- a/src/http.c
+++ b/src/http.c
@@ -44,6 +44,10 @@ static int http_perform_rec(const http_request_t *request, http_response_t *resp
 		return ret;
 	}
 
+	// Keep the original "host[:port]" string for the Host header before stripping the port
+	char host_header[HTTP_MAX_HOST_LEN];
+	memcpy(host_header, host, host_len + 1);
+
 	const char *service;
 	char *separator = strchr(host, ':');
 	if (separator) {
@@ -93,7 +97,7 @@ static int http_perform_rec(const http_request_t *request, http_response_t *resp
 		               "Content-Length: %zu\r\n"
 		               "Content-Type: %s\r\n"
 		               "%s\r\n",
-		               method_str, *path != '\0' ? path : "/", host, request->body_size,
+		               method_str, *path != '\0' ? path : "/", host_header, request->body_size,
 		               request->body_type, request->headers ? request->headers : "");
 	else
 		len = snprintf(buffer, size,
@@ -101,7 +105,7 @@ static int http_perform_rec(const http_request_t *request, http_response_t *resp
 		               "Host: %s\r\n"
 		               "Connection: close\r\n"
 		               "%s\r\n",
-		               method_str, *path != '\0' ? path : "/", host,
+		               method_str, *path != '\0' ? path : "/", host_header,
 		               request->headers ? request->headers : "");
 
 	if (len < 0 || (size_t)len >= size) {

--- a/src/http.c
+++ b/src/http.c
@@ -166,10 +166,23 @@ static int http_perform_rec(const http_request_t *request, http_response_t *resp
 	PLUM_LOG_VERBOSE("Received HTTP response: %s", buffer);
 
 	int code = 0;
-	if (sscanf(buffer, "HTTP/%*s %d %*s\n%n", &code, &len) != 1 || code <= 0) {
+	int header_len = 0;
+	// Parse status line: "HTTP/<version> <code> [reason]\r\n"
+	// %*s matches the version, then optionally skip the reason phrase.
+	// We use two patterns to handle responses with and without a reason phrase.
+	if (sscanf(buffer, "HTTP/%*s %d %*[^\r\n]%n", &code, &header_len) < 1 &&
+	    sscanf(buffer, "HTTP/%*s %d%n", &code, &header_len) < 1) {
 		PLUM_LOG_WARN("Failed to parse HTTP response status");
 		goto error;
 	}
+	if (code <= 0) {
+		PLUM_LOG_WARN("Failed to parse HTTP response status");
+		goto error;
+	}
+	// Find the end of the status line to advance past \r\n
+	const char *eol = strstr(buffer + header_len, "\r\n");
+	if (!eol) eol = strstr(buffer + header_len, "\n");
+	len = eol ? (int)(eol - buffer) + (eol[0] == '\r' ? 2 : 1) : header_len;
 
 	PLUM_LOG_DEBUG("Got HTTP response code %d", code);
 

--- a/src/natpmp.c
+++ b/src/natpmp.c
@@ -233,7 +233,7 @@ int natpmp_impl_check_epoch_time(pcp_impl_t *impl, uint32_t curr_server_time) {
 	// from the gateway and adding 7/8 (87.5%) of the time elapsed according to the client's local
 	// clock since that packet was received.
 	uint32_t elapsed = curr_client_time - impl->prev_client_time;
-	uint32_t estimated_server_time = curr_server_time + elapsed - elapsed / 8;
+	uint32_t estimated_server_time = impl->prev_server_time + elapsed - elapsed / 8;
 
 	impl->prev_client_time = curr_client_time;
 	impl->prev_server_time = curr_server_time;

--- a/src/noprotocol.c
+++ b/src/noprotocol.c
@@ -52,7 +52,6 @@ int noprotocol_discover(protocol_state_t *state, timediff_t duration) {
 
 int noprotocol_map(protocol_state_t *state, const client_mapping_t *mapping,
                    protocol_map_output_t *output, timediff_t duration) {
-	(void)state;
 	(void)duration;
 	memset(output, 0, sizeof(*output));
 
@@ -66,7 +65,9 @@ int noprotocol_map(protocol_state_t *state, const client_mapping_t *mapping,
 			}
 
 			output->state = PROTOCOL_MAP_STATE_SUCCESS;
-			output->refresh_timestamp = current_timestamp() + CLIENT_RECHECK_PERIOD;
+			// Reachable directly, no port mapping was performed
+			output->mapping_protocol = PLUM_MAPPING_PROTOCOL_DIRECT;
+			output->refresh_timestamp = current_timestamp() + state->recheck_period;
 			output->external_addr = local;
 			addr_set_port((struct sockaddr *)&output->external_addr, mapping->internal_port);
 			return PROTOCOL_ERR_SUCCESS;
@@ -76,7 +77,7 @@ int noprotocol_map(protocol_state_t *state, const client_mapping_t *mapping,
 	}
 
 	output->state = PROTOCOL_MAP_STATE_FAILURE;
-	output->refresh_timestamp = current_timestamp() + CLIENT_RECHECK_PERIOD;
+	output->refresh_timestamp = current_timestamp() + state->recheck_period;
 	memset(&output->external_addr, 0, sizeof(output->external_addr));
 	return PROTOCOL_ERR_SUCCESS; // report mapping failure but keep running the protocol
 }

--- a/src/pcp.c
+++ b/src/pcp.c
@@ -94,7 +94,6 @@ int pcp_discover(protocol_state_t *state, timediff_t duration) {
 	// the interval between attempts doubling each time.
 	int probe_count = 0;
 	timediff_t probe_duration = 250;
-probe_retry:
 	do {
 		timestamp_t probe_end_timestamp = current_timestamp() + probe_duration;
 		if (probe_end_timestamp > end_timestamp)
@@ -130,14 +129,6 @@ probe_retry:
 
 		probe_duration *= 2;
 	} while (++probe_count < PCP_MAX_ATTEMPTS && current_timestamp() < end_timestamp);
-
-	if (!impl->use_natpmp) {
-		PLUM_LOG_DEBUG("PCP timed out with no response, trying NAT-PMP");
-		impl->use_natpmp = true;
-		probe_count = 0;
-		probe_duration = 250;
-		goto probe_retry;
-	}
 
 	return PROTOCOL_ERR_TIMEOUT;
 }

--- a/src/pcp.c
+++ b/src/pcp.c
@@ -558,6 +558,7 @@ int pcp_impl_check_epoch_time(pcp_impl_t *impl, uint32_t curr_server_time) {
 	// ... If this is the first PCP response the client has received from this PCP server, the Epoch
 	// Time value is treated as necessarily valid
 	if (!impl->has_prev_server_time) {
+		impl->has_prev_server_time = true;
 		is_valid = true;
 	}
 	// ... If the current PCP server Epoch time (curr_server_time) is less than the previously

--- a/src/pcp.c
+++ b/src/pcp.c
@@ -179,11 +179,13 @@ int pcp_map(protocol_state_t *state, const client_mapping_t *mapping, protocol_m
 		}
 
 		if (err == PROTOCOL_ERR_SUCCESS) {
-			if (impl->use_natpmp)
+			if (impl->use_natpmp) {
 				PLUM_LOG_DEBUG("Success mapping with NAT-PMP");
-			else
+				output->mapping_protocol = PLUM_MAPPING_PROTOCOL_NATPMP;
+			} else {
 				PLUM_LOG_DEBUG("Success mapping with PCP");
-
+				output->mapping_protocol = PLUM_MAPPING_PROTOCOL_PCP;
+			}
 			return PROTOCOL_ERR_SUCCESS;
 		}
 
@@ -487,8 +489,6 @@ int pcp_impl_map(pcp_impl_t *impl, const client_mapping_t *mapping, protocol_map
 			lifetime = response_lifetime;
 
 		output->state = PROTOCOL_MAP_STATE_SUCCESS;
-		output->mapping_protocol =
-		    impl->use_natpmp ? PLUM_MAPPING_PROTOCOL_NATPMP : PLUM_MAPPING_PROTOCOL_PCP;
 
 		// RFC 6887: The PCP client SHOULD renew the mapping before its expiry time; otherwise, it
 		// will be removed by the PCP server. To reduce the risk of inadvertent synchronization of

--- a/src/pcp.c
+++ b/src/pcp.c
@@ -94,6 +94,7 @@ int pcp_discover(protocol_state_t *state, timediff_t duration) {
 	// the interval between attempts doubling each time.
 	int probe_count = 0;
 	timediff_t probe_duration = 250;
+probe_retry:
 	do {
 		timestamp_t probe_end_timestamp = current_timestamp() + probe_duration;
 		if (probe_end_timestamp > end_timestamp)
@@ -129,6 +130,14 @@ int pcp_discover(protocol_state_t *state, timediff_t duration) {
 
 		probe_duration *= 2;
 	} while (++probe_count < PCP_MAX_ATTEMPTS && current_timestamp() < end_timestamp);
+
+	if (!impl->use_natpmp) {
+		PLUM_LOG_DEBUG("PCP timed out with no response, trying NAT-PMP");
+		impl->use_natpmp = true;
+		probe_count = 0;
+		probe_duration = 250;
+		goto probe_retry;
+	}
 
 	return PROTOCOL_ERR_TIMEOUT;
 }

--- a/src/pcp.c
+++ b/src/pcp.c
@@ -487,6 +487,8 @@ int pcp_impl_map(pcp_impl_t *impl, const client_mapping_t *mapping, protocol_map
 			lifetime = response_lifetime;
 
 		output->state = PROTOCOL_MAP_STATE_SUCCESS;
+		output->mapping_protocol =
+		    impl->use_natpmp ? PLUM_MAPPING_PROTOCOL_NATPMP : PLUM_MAPPING_PROTOCOL_PCP;
 
 		// RFC 6887: The PCP client SHOULD renew the mapping before its expiry time; otherwise, it
 		// will be removed by the PCP server. To reduce the risk of inadvertent synchronization of

--- a/src/plum.c
+++ b/src/plum.c
@@ -36,6 +36,10 @@ PLUM_EXPORT int plum_init(const plum_config_t *config) {
 	if (!client)
 		return PLUM_ERR_FAILED;
 
+	client->discover_timeout = config->discover_timeout > 0 ? config->discover_timeout : CLIENT_MAX_DISCOVER_TIMEOUT;
+	client->mapping_timeout  = config->mapping_timeout  > 0 ? config->mapping_timeout  : CLIENT_MAX_MAPPING_TIMEOUT;
+	client->recheck_period   = config->recheck_period   > 0 ? config->recheck_period   : CLIENT_RECHECK_PERIOD;
+
 	return PLUM_ERR_SUCCESS;
 }
 

--- a/src/plum.c
+++ b/src/plum.c
@@ -22,6 +22,9 @@ PLUM_EXPORT int plum_init(const plum_config_t *config) {
 	if (client)
 		return PLUM_ERR_FAILED;
 
+	if (!config)
+		return PLUM_ERR_INVALID;
+
 	plum_log_init();
 	plum_set_log_level(config->log_level);
 	plum_set_log_handler(config->log_callback);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -39,6 +39,7 @@ typedef enum {
 
 typedef struct {
 	protocol_map_state_t state;
+	plum_mapping_protocol_t mapping_protocol;
 	addr_record_t external_addr;
 	timestamp_t refresh_timestamp;
 	void *impl_record;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,6 +15,8 @@
 typedef struct {
 	addr_record_t gateway;
 	void *impl;
+	// Configured recheck period, used by the no-protocol fallback for its refresh delay
+	timediff_t recheck_period;
 } protocol_state_t;
 
 struct client_mapping;

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -438,8 +438,8 @@ int upnp_impl_query_external_addr(upnp_impl_t *impl, timestamp_t end_timestamp) 
 
 	char header_buffer[UPNP_BUFFER_SIZE];
 	int header_len = snprintf(header_buffer, UPNP_BUFFER_SIZE,
-                              "SOAPAction: urn:schemas-upnp-org:service:%s:%d#GetExternalIPAddress\r\n",
-                              impl->service, impl->version);
+	                          "SOAPAction: \"urn:schemas-upnp-org:service:%s:%d#GetExternalIPAddress\"\r\n",
+	                          impl->service, impl->version);
 	if (header_len <= 0 || header_len >= UPNP_BUFFER_SIZE) {
 		PLUM_LOG_ERROR("Failed to format SOAP request headers");
 		return PROTOCOL_ERR_UNKNOWN;
@@ -523,13 +523,13 @@ int upnp_impl_map(upnp_impl_t *impl, plum_ip_protocol_t protocol, uint16_t exter
 
 	char header_buffer[UPNP_BUFFER_SIZE];
 	int header_len = snprintf(header_buffer, UPNP_BUFFER_SIZE,
-                              "SOAPAction: urn:schemas-upnp-org:service:%s:%d#AddPortMapping\r\n",
-                              impl->service, impl->version);
+	                          "SOAPAction: \"urn:schemas-upnp-org:service:%s:%d#AddPortMapping\"\r\n",
+	                          impl->service, impl->version);
 	if (header_len <= 0 || header_len >= UPNP_BUFFER_SIZE) {
 		PLUM_LOG_ERROR("Failed to format SOAP request headers");
 		return PROTOCOL_ERR_UNKNOWN;
 	}
-    request.headers = header_buffer;
+	request.headers = header_buffer;
 
 	char body_buffer[UPNP_BUFFER_SIZE];
 	int body_len = snprintf(body_buffer, UPNP_BUFFER_SIZE,
@@ -606,13 +606,13 @@ int upnp_impl_unmap(upnp_impl_t *impl, plum_ip_protocol_t protocol, uint16_t ext
 
 	char header_buffer[UPNP_BUFFER_SIZE];
 	int header_len = snprintf(header_buffer, UPNP_BUFFER_SIZE,
-                              "SOAPAction: urn:schemas-upnp-org:service:%s:%d#DeletePortMapping\r\n",
-                              impl->service, impl->version);
+	                          "SOAPAction: \"urn:schemas-upnp-org:service:%s:%d#DeletePortMapping\"\r\n",
+	                          impl->service, impl->version);
 	if (header_len <= 0 || header_len >= UPNP_BUFFER_SIZE) {
 		PLUM_LOG_ERROR("Failed to format SOAP request headers");
 		return PROTOCOL_ERR_UNKNOWN;
 	}
-    request.headers = header_buffer;
+	request.headers = header_buffer;
 
 	char body_buffer[UPNP_BUFFER_SIZE];
 	int body_len = snprintf(body_buffer, UPNP_BUFFER_SIZE,

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -241,15 +241,19 @@ int upnp_impl_probe(upnp_impl_t *impl, addr_record_t *found_gateway, timestamp_t
 	char broadcast_str[ADDR_MAX_STRING_LEN];
 	addr_record_to_string(&broadcast, broadcast_str, ADDR_MAX_STRING_LEN);
 
+	timediff_t remaining = end_timestamp - current_timestamp();
+	int mx = (int)(remaining / 1000);
+	if (mx < 1) mx = 1;
+
 	char buffer[UPNP_BUFFER_SIZE];
 	int len = snprintf(buffer, UPNP_BUFFER_SIZE,
 	                   "M-SEARCH * HTTP/1.1\r\n"
 	                   "HOST: %s\r\n"
 	                   "MAN: \"ssdp:discover\"\r\n"
-	                   "MX: 10\r\n"
+	                   "MX: %d\r\n"
 	                   "ST: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n"
 					   "\r\n",
-	                   broadcast_str);
+	                   broadcast_str, mx);
 
 	if (len <= 0 || len >= UPNP_BUFFER_SIZE) {
 		PLUM_LOG_ERROR("Failed to write SSDP message to buffer");

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -153,6 +153,7 @@ int upnp_map(protocol_state_t *state, const client_mapping_t *mapping,
 		if (err == PROTOCOL_ERR_SUCCESS) {
 			PLUM_LOG_DEBUG("Success mapping with UPnP");
 			output->state = PROTOCOL_MAP_STATE_SUCCESS;
+			output->mapping_protocol = PLUM_MAPPING_PROTOCOL_UPNP;
 			output->refresh_timestamp =
 			    current_timestamp() + (lifetime / 2) * 1000; // halfway expiry time
 			addr_set(AF_INET, impl->external_addr_str, external_port, &output->external_addr);

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -245,6 +245,8 @@ int upnp_impl_probe(upnp_impl_t *impl, addr_record_t *found_gateway, timestamp_t
 	timediff_t remaining = end_timestamp - current_timestamp();
 	int mx = (int)(remaining / 1000);
 	if (mx < 1) mx = 1;
+	// UPnP Device Architecture: MX should not exceed 5 (devices clamp it anyway)
+	if (mx > 5) mx = 5;
 
 	char buffer[UPNP_BUFFER_SIZE];
 	int len = snprintf(buffer, UPNP_BUFFER_SIZE,


### PR DESCRIPTION
## Summary

Add configurable discovery/mapping/recheck timeouts, expose which protocol mapped the port, and fix several PCP/NAT-PMP/UPnP bugs found during testing.

## Features

- **Configurable timeouts**: `plum_config_t` gains `discover_timeout`, `mapping_timeout`, `recheck_period` (`0` = previous defaults). The struct must be zero-initialized.
- **Expose mapping protocol**: new `plum_mapping_protocol_t` (PCP/NATPMP/UPNP/DIRECT) on `plum_mapping_t`.

## Bug fixes

- **Epoch reset detection was dead**: PCP never set `has_prev_server_time`
- **UPnP SOAPAction** missing required quotes 
- **SSDP MX** hardcoded to 10, now derived from the actual discovery window.
- **HTTP**: the Host header was missing the port when the URL used a port other than 80.
- **Lock leak** in `has_destroying_mappings` 
- **Public IP**: the mapping was needlessly re-created on every cycle when the machine has a public address, re-firing callbacks; this now only happens when retrying a real NAT.
- **No-protocol mode**: now respects the configured `recheck_period` and reports the mapping as `DIRECT`.

## Robustness

- Fall back to NAT-PMP when PCP times out
- Reject a `NULL` config with `PLUM_ERR_INVALID`.
- Simplify HTTP status-line parsing; ignore `example.out`.