### PR TITLE
feat: add protocol filter to config to restrict discovery to PCP or UPnP

### DIFF
--- a/include/plum/plum.h
+++ b/include/plum/plum.h
@@ -53,6 +53,12 @@ typedef enum {
 
 typedef void (*plum_log_callback_t)(plum_log_level_t level, const char *message);
 
+typedef enum {
+	PLUM_PROTOCOL_ANY = 0, // try all protocols (default)
+	PLUM_PROTOCOL_PCP = 1, // PCP/NAT-PMP only
+	PLUM_PROTOCOL_UPNP = 2 // UPnP only
+} plum_protocol_t;
+
 // Must be zero-initialized (e.g. plum_config_t config = {0}); unset fields fall back to defaults.
 typedef struct {
 	plum_log_level_t log_level;
@@ -61,6 +67,7 @@ typedef struct {
 	int discover_timeout; // msecs, 0 means use default (10000)
 	int mapping_timeout;  // msecs, 0 means use default (10000)
 	int recheck_period;   // msecs, 0 means use default (300000)
+	plum_protocol_t protocol; // PLUM_PROTOCOL_ANY means try all
 } plum_config_t;
 
 PLUM_EXPORT int plum_init(const plum_config_t *config);

--- a/src/client.c
+++ b/src/client.c
@@ -74,7 +74,24 @@ thread_return_t THREAD_CALL client_thread_entry(void *arg) {
 	return (thread_return_t)0;
 }
 
-client_t *client_create(void) {
+// NOPROTOCOL is always enabled as the terminal fallback
+static bool protocol_is_enabled(const client_t *client, int protocol_num) {
+	if (protocol_num == PROTOCOL_NOPROTOCOL)
+		return true;
+	if (client->protocol_filter == PLUM_PROTOCOL_PCP)
+		return protocol_num == PROTOCOL_PCP;
+	if (client->protocol_filter == PLUM_PROTOCOL_UPNP)
+		return protocol_num == PROTOCOL_UPNP;
+	return true; // PLUM_PROTOCOL_ANY
+}
+
+static int next_protocol_num(const client_t *client, int protocol_num) {
+	while (protocol_num < PROTOCOLS_COUNT && !protocol_is_enabled(client, protocol_num))
+		++protocol_num;
+	return protocol_num;
+}
+
+client_t *client_create(plum_protocol_t protocol_filter) {
 	PLUM_LOG_DEBUG("Creating client");
 
 #ifdef _WIN32
@@ -101,6 +118,7 @@ client_t *client_create(void) {
 
 	memset(client->mappings, 0, DEFAULT_MAPPINGS_SIZE * sizeof(client_mapping_t));
 	client->mappings_size = DEFAULT_MAPPINGS_SIZE;
+	client->protocol_filter = protocol_filter;
 	mutex_init(&client->mappings_mutex, MUTEX_RECURSIVE); // so the user call the API from callbacks
 	mutex_init(&client->protocol_mutex, 0);
 
@@ -320,7 +338,7 @@ void client_run(client_t *client) {
 
 	addr_record_t old_local;
 	memset(&old_local, 0, sizeof(old_local));
-	int protocol_num = 0;
+	int protocol_num = next_protocol_num(client, 0);
 	while (true) {
 		addr_record_t local;
 		if (net_get_default_interface(AF_INET, &local) < 0) {
@@ -333,7 +351,7 @@ void client_run(client_t *client) {
 		if (changed) {
 			PLUM_LOG_INFO("Local address changed, restarting");
 			reset_protocol(client);
-			protocol_num = 0;
+			protocol_num = next_protocol_num(client, 0);
 		}
 
 		if (protocol_num != PROTOCOL_NOPROTOCOL &&
@@ -379,7 +397,7 @@ void client_run(client_t *client) {
 			    !addr_is_public((const struct sockaddr *)&local)) {
 				PLUM_LOG_DEBUG("Retrying discovery");
 				reset_protocol(client);
-				protocol_num = 0;
+				protocol_num = next_protocol_num(client, 0);
 			}
 			continue;
 		}
@@ -396,7 +414,7 @@ void client_run(client_t *client) {
 
 		PLUM_LOG_DEBUG("Protocol failed");
 
-		++protocol_num;
+		protocol_num = next_protocol_num(client, protocol_num + 1);
 		if (protocol_num >= PROTOCOLS_COUNT) {
 			PLUM_LOG_FATAL("Client failed, exiting");
 			break;

--- a/src/client.h
+++ b/src/client.h
@@ -38,6 +38,7 @@ typedef struct {
 	mutex_t mappings_mutex;
 	const protocol_t *protocol;
 	protocol_state_t protocol_state;
+	plum_protocol_t protocol_filter;
 	mutex_t protocol_mutex;
 	bool is_started;
 	atomic(bool) is_stopping;
@@ -47,7 +48,7 @@ typedef struct {
 	timediff_t recheck_period;
 } client_t;
 
-client_t *client_create(void);
+client_t *client_create(plum_protocol_t protocol_filter);
 void client_destroy(client_t *client);
 int client_start(client_t *client);
 int client_add_mapping(client_t *client, const plum_mapping_t *mapping,

--- a/src/plum.c
+++ b/src/plum.c
@@ -35,7 +35,7 @@ PLUM_EXPORT int plum_init(const plum_config_t *config) {
 	if (config->dummytls_domain)
 		dummytls_set_domain(config->dummytls_domain);
 
-	client = client_create();
+	client = client_create(config->protocol);
 	if (!client)
 		return PLUM_ERR_FAILED;
 


### PR DESCRIPTION
Adds an optional protocol field to plum_config_t to restrict discovery to a single family (PLUM_PROTOCOL_PCP covers PCP/NAT-PMP, PLUM_PROTOCOL_UPNP covers UPnP) instead of always trying all. This is needed for [some open source projects](https://github.com/status-im/nim-nat-traversal). 

NOPROTOCOL stays enabled as the terminal fallback. Backward compatible: PLUM_PROTOCOL_ANY = 0, so zero-initialized configs behave as before.